### PR TITLE
Add authentication for pulling image from Docker Hub 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,9 @@ jobs:
   build:
     docker:
       - image: circleci/ruby:2.5-stretch-node
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_PASSWORD
     executor: ruby/default
     steps:
       - checkout


### PR DESCRIPTION
Add authentication to avoid Docker Hub download rate limit.
User name and password of Docker Hub are already registered as environment variables.

https://docs.docker.com/docker-hub/download-rate-limit/